### PR TITLE
Customizable library paths (closes #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-11
+
+Resolves [#1](https://github.com/hulryung/kicad-lcsc-manager/issues/1): library paths are now user-customizable at two scopes (global and per-project), via a new in-plugin Settings dialog. No more editing JSON by hand to change where imports land.
+
+### Added
+- **Settings dialog** reachable from the ⚙ button in the import dialog. Edits four path values — library root, symbol file name, footprint folder, 3D model folder — with live path preview, input validation, and a per-field source badge (`[global]`, `[project]`, `[default]`, `[edited]`, `[source → scope]`).
+- **Per-project overrides** via `<project>/.lcsc_manager.json`. Layered resolution: `default < global (~/.kicad/lcsc_manager/config.json) < project`. Each layer may store any subset of keys.
+- **Scope-aware preview** in the Settings dialog: Global view shows `${KIPRJMOD}/…` template paths (project-agnostic), Project view shows the resolved absolute path against the currently open project, with `✓ exists` / `(will create)` indicators.
+- **Import destination panel** in the main search dialog showing where the next import will land and which scope's settings are active (`This project only`, `Global`, `Default`, or `Project override + Global/Default for the rest`).
+- Unit tests for config layering (`test_config_layering.py`, 13 tests), lib-table URI generation (`test_library_manager_uris.py`, 3 tests), and footprint converter 3D URI plumbing (`test_footprint_converter_3d_uri.py`, 3 tests).
+
+### Fixed
+- **Hardcoded library paths**: `sym-lib-table` URI, `fp-lib-table` URI, and the 3D model reference inside generated `.kicad_mod` files were embedded as string literals (`${KIPRJMOD}/libs/lcsc/...`). They now flow from the user's config so customization actually takes effect end-to-end.
+
+### Changed
+- Global config file is no longer seeded with defaults on first run. `~/.kicad/lcsc_manager/config.json` starts empty so the Settings UI can accurately mark which keys are real user overrides vs. inherited defaults.
+
 ## [0.3.0] - 2026-04-08
 
 Major integration of fixes ported from [easyeda2kicad.py v1.0.1](https://github.com/uPesy/easyeda2kicad.py) upstream. Improves correctness for footprint layer assignment, multi-unit symbol pin numbers, 3D model placement, and via handling. Several latent bugs in the JLC2KiCad_lib fork are fixed.

--- a/README.md
+++ b/README.md
@@ -145,10 +145,35 @@ A KiCad plugin that allows you to search and import electronic components from L
 
 7. **Click "Import Selected"** to add the component to your project
 
-8. **Find imported components** in your project libraries:
+8. **Find imported components** in your project libraries (default paths):
    - Symbol: `<project>/libs/lcsc/symbols/lcsc_imported.kicad_sym`
    - Footprint: `<project>/libs/lcsc/footprints.pretty/`
    - 3D Models: `<project>/libs/lcsc/3dmodels/`
+
+### Customizing library paths
+
+Click the **⚙ Settings…** button in the import dialog to change where LCSC
+components are stored. Four values are configurable:
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `library_path` | `libs/lcsc` | Root folder relative to the project |
+| `symbol_lib_name` | `lcsc_imported.kicad_sym` | Symbol library filename |
+| `footprint_lib_name` | `footprints.pretty` | Footprint library folder |
+| `model_3d_path` | `3dmodels` | 3D model folder |
+
+Settings can be saved at one of two scopes:
+
+- **Global** — `~/.kicad/lcsc_manager/config.json`. Applies to every project
+  unless overridden.
+- **This project only** — `<project>/.lcsc_manager.json`. Overrides the
+  global config for that project. Commit this file if you want the layout
+  shared with your team, or add it to `.gitignore` if it's personal.
+
+Resolution order is `default < global < project`. The Settings dialog shows a
+live preview of the resolved absolute paths and indicates which scope each
+value comes from. Changes apply to *future* imports only — existing libraries
+are not moved automatically.
 
 ### Tips
 

--- a/plugins/lcsc_manager/__init__.py
+++ b/plugins/lcsc_manager/__init__.py
@@ -7,7 +7,7 @@ directly into KiCad projects with symbols, footprints, and 3D models.
 import os
 import sys
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __author__ = "hulryung"
 __license__ = "MIT"
 

--- a/plugins/lcsc_manager/converters/footprint_converter.py
+++ b/plugins/lcsc_manager/converters/footprint_converter.py
@@ -44,9 +44,18 @@ class FootprintInfo:
 class FootprintConverter:
     """Converter for EasyEDA footprints to KiCad format"""
 
-    def __init__(self):
-        """Initialize footprint converter"""
+    def __init__(self, model_uri_base: str = "${KIPRJMOD}/libs/lcsc/3dmodels"):
+        """
+        Initialize footprint converter.
+
+        Args:
+            model_uri_base: URI prefix used for 3D model references inside
+                            generated .kicad_mod files. Trailing slash is
+                            stripped. Defaults to the historical hardcoded
+                            value so callers that don't pass it still work.
+        """
         self.logger = get_logger("footprint_converter")
+        self.model_uri_base = model_uri_base.rstrip("/")
 
     def convert(
         self,
@@ -216,7 +225,7 @@ class FootprintConverter:
             # - Includes color information
             # - KiCad native format
             # STEP file is also downloaded for MCAD export but not referenced in footprint
-            wrl_path = f"${{KIPRJMOD}}/libs/lcsc/3dmodels/{lcsc_id}.wrl"
+            wrl_path = f"{self.model_uri_base}/{lcsc_id}.wrl"
             kicad_mod.append(
                 Model(
                     filename=wrl_path,
@@ -300,7 +309,7 @@ class FootprintConverter:
   (fp_rect (start -1.2 -0.8) (end 1.2 0.8) (layer "F.Fab") (width 0.1) (fill none))
   (pad "1" smd rect (at -1 0) (size 0.8 1.2) (layers "F.Cu" "F.Paste" "F.Mask"))
   (pad "2" smd rect (at 1 0) (size 0.8 1.2) (layers "F.Cu" "F.Paste" "F.Mask"))
-  (model "${{KIPRJMOD}}/libs/lcsc/3dmodels/{lcsc_id}.wrl"
+  (model "{self.model_uri_base}/{lcsc_id}.wrl"
     (offset (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/plugins/lcsc_manager/dialog.py
+++ b/plugins/lcsc_manager/dialog.py
@@ -395,9 +395,19 @@ class LCSCManagerDialog(wx.Dialog):
         self._refresh_lib_info()
 
     def _refresh_lib_info(self):
-        """Update the 'Components will be saved to: …' label."""
+        """Update the 'Components will be saved to: …' label, including
+        which scope's settings are active."""
         lib_path = self.config.get_library_path(self.project_path)
-        self.lib_info.SetLabel(f"Components will be saved to: {lib_path}")
+        summary = self.config.get_active_scope_summary()
+        scope_text = {
+            "project": "this project only",
+            "mixed":   "project + global",
+            "global":  "global settings",
+            "default": "default settings",
+        }[summary]
+        self.lib_info.SetLabel(
+            f"Components will be saved to: {lib_path}  (source: {scope_text})"
+        )
         self.Layout()
 
     def _on_import(self, event):

--- a/plugins/lcsc_manager/dialog.py
+++ b/plugins/lcsc_manager/dialog.py
@@ -125,6 +125,7 @@ class LCSCManagerDialog(wx.Dialog):
 
         self.project_path = project_path
         self.config = get_config()
+        self.config.load_project_overrides(project_path)
         self.api_client = get_api_client()
         self.library_manager = LibraryManager(project_path)
 
@@ -217,16 +218,21 @@ class LCSCManagerDialog(wx.Dialog):
         main_sizer.Add(options_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
         main_sizer.AddSpacer(10)
 
-        # Library path info
-        lib_path = self.config.get_library_path(self.project_path)
-        lib_info = wx.StaticText(
-            self,
-            label=f"Components will be saved to: {lib_path}"
-        )
-        lib_info.SetForegroundColour(wx.Colour(100, 100, 100))
-        main_sizer.Add(lib_info, 0, wx.ALL | wx.EXPAND, 10)
+        # Library path info — kept as an instance attr so we can refresh
+        # the label after the Settings dialog mutates the config.
+        self.lib_info = wx.StaticText(self, label="")
+        self.lib_info.SetForegroundColour(wx.Colour(100, 100, 100))
+        self._refresh_lib_info()
+        main_sizer.Add(self.lib_info, 0, wx.ALL | wx.EXPAND, 10)
 
-        # Buttons
+        # Buttons row: Settings on the left, OK/Cancel on the right.
+        button_row = wx.BoxSizer(wx.HORIZONTAL)
+
+        settings_btn = wx.Button(self, label="⚙ Settings…")
+        settings_btn.Bind(wx.EVT_BUTTON, self._on_settings)
+        button_row.Add(settings_btn, 0, wx.ALIGN_CENTER_VERTICAL)
+        button_row.AddStretchSpacer()
+
         button_sizer = wx.StdDialogButtonSizer()
 
         import_btn = wx.Button(self, wx.ID_OK, "Import")
@@ -237,7 +243,8 @@ class LCSCManagerDialog(wx.Dialog):
         button_sizer.AddButton(cancel_btn)
 
         button_sizer.Realize()
-        main_sizer.Add(button_sizer, 0, wx.EXPAND | wx.ALL, 10)
+        button_row.Add(button_sizer, 0)
+        main_sizer.Add(button_row, 0, wx.EXPAND | wx.ALL, 10)
 
         self.SetSizer(main_sizer)
         self.Layout()
@@ -370,6 +377,28 @@ class LCSCManagerDialog(wx.Dialog):
                 wx.OK | wx.ICON_ERROR
             )
             self.info_text.SetValue("Search failed with unexpected error.")
+
+    def _on_settings(self, event):
+        """Open the LCSC Manager settings dialog."""
+        # Local import to avoid wx import at module load time during tests
+        from .dialog_settings import SettingsDialog
+        dlg = SettingsDialog(self, self.config, self.project_path)
+        try:
+            dlg.ShowModal()
+        finally:
+            dlg.Destroy()
+        # Re-resolve paths in case the user changed them so the next import
+        # check / library write uses fresh values. Rebuild library_manager
+        # too — its cached paths and footprint-converter URI are stale.
+        self.config.load_project_overrides(self.project_path)
+        self.library_manager = LibraryManager(self.project_path)
+        self._refresh_lib_info()
+
+    def _refresh_lib_info(self):
+        """Update the 'Components will be saved to: …' label."""
+        lib_path = self.config.get_library_path(self.project_path)
+        self.lib_info.SetLabel(f"Components will be saved to: {lib_path}")
+        self.Layout()
 
     def _on_import(self, event):
         """Handle import button click"""
@@ -558,7 +587,11 @@ class LCSCManagerDialog(wx.Dialog):
         Returns:
             Dictionary with exists flags for symbol, footprint, 3d_model
         """
-        lib_path = self.config.get_library_path(self.project_path)
+        self.config.load_project_overrides(self.project_path)
+        symbol_file = self.config.get_symbol_lib_path(self.project_path)
+        footprint_dir = self.config.get_footprint_lib_path(self.project_path)
+        model_dir = self.config.get_3d_model_path(self.project_path)
+
         lcsc_id = component_info.get("lcsc_id", "")
         package = component_info.get("package", "Unknown")
         symbol_name = component_info.get("description", component_info.get("name", ""))
@@ -571,7 +604,6 @@ class LCSCManagerDialog(wx.Dialog):
         }
 
         # Check symbol - need to parse the library file
-        symbol_file = lib_path / "symbols" / "lcsc_imported.kicad_sym"
         if symbol_file.exists():
             try:
                 # Check file size to avoid reading huge files into memory
@@ -603,11 +635,10 @@ class LCSCManagerDialog(wx.Dialog):
                           .replace(":", "{colon}")
                           .replace('"', "{dblquote}"))
         footprint_name = f"{lcsc_id}_{footprint_name}"
-        footprint_file = lib_path / "footprints.pretty" / f"{footprint_name}.kicad_mod"
+        footprint_file = footprint_dir / f"{footprint_name}.kicad_mod"
         exists["footprint"] = footprint_file.exists()
 
         # Check 3D models - separate files
-        model_dir = lib_path / "3dmodels"
         exists["3d_wrl"] = (model_dir / f"{lcsc_id}.wrl").exists()
         exists["3d_step"] = (model_dir / f"{lcsc_id}.step").exists()
 

--- a/plugins/lcsc_manager/dialog_search.py
+++ b/plugins/lcsc_manager/dialog_search.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from .api.lcsc_api import get_api_client, LCSCAPIError
 from .library.library_manager import LibraryManager
 from .utils.logger import get_logger
+from .utils.config import get_config
 
 logger = get_logger()
 
@@ -35,6 +36,8 @@ class LCSCManagerSearchDialog(wx.Dialog):
         )
 
         self.project_path = Path(project_path)
+        self.config = get_config()
+        self.config.load_project_overrides(self.project_path)
         self.api_client = get_api_client()
         self.library_manager = LibraryManager(self.project_path)
 
@@ -103,13 +106,20 @@ class LCSCManagerSearchDialog(wx.Dialog):
         options_panel = self._create_import_options_panel()
         main_sizer.Add(options_panel, 0, wx.EXPAND | wx.ALL, 10)
 
-        # Buttons
+        # Bottom row: ⚙ Settings on the left, OK/Cancel on the right.
+        button_row = wx.BoxSizer(wx.HORIZONTAL)
+        settings_btn = wx.Button(self, label="⚙ Settings…")
+        settings_btn.Bind(wx.EVT_BUTTON, self._on_settings)
+        button_row.Add(settings_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 10)
+        button_row.AddStretchSpacer()
+
         button_sizer = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
         import_btn = wx.FindWindowById(wx.ID_OK, self)
         import_btn.SetLabel("Import Selected")
         import_btn.Bind(wx.EVT_BUTTON, self._on_import)
+        button_row.Add(button_sizer, 0, wx.RIGHT, 10)
 
-        main_sizer.Add(button_sizer, 0, wx.EXPAND | wx.ALL, 10)
+        main_sizer.Add(button_row, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 
         self.SetSizer(main_sizer)
 
@@ -751,6 +761,19 @@ class LCSCManagerSearchDialog(wx.Dialog):
     def _update_specs(self, specs_text: str):
         """Update only the specifications text (called when component data finishes loading)"""
         self.specs_text.SetValue(specs_text)
+
+    def _on_settings(self, event):
+        """Open the LCSC Manager settings dialog."""
+        from .dialog_settings import SettingsDialog
+        dlg = SettingsDialog(self, self.config, self.project_path)
+        try:
+            dlg.ShowModal()
+        finally:
+            dlg.Destroy()
+        # Re-read overrides and rebuild the library manager so its cached
+        # paths and the footprint converter's 3D URI reflect the new config.
+        self.config.load_project_overrides(self.project_path)
+        self.library_manager = LibraryManager(self.project_path)
 
     def _on_import(self, event):
         """Handle import button click - runs fetch+import in background thread"""

--- a/plugins/lcsc_manager/dialog_search.py
+++ b/plugins/lcsc_manager/dialog_search.py
@@ -106,6 +106,31 @@ class LCSCManagerSearchDialog(wx.Dialog):
         options_panel = self._create_import_options_panel()
         main_sizer.Add(options_panel, 0, wx.EXPAND | wx.ALL, 10)
 
+        # Destination summary: where this import will land + which scope's
+        # settings are active. Kept as instance attrs so Settings can
+        # trigger a refresh after save.
+        dest_box = wx.StaticBox(self, label="Import destination")
+        dest_sizer = wx.StaticBoxSizer(dest_box, wx.VERTICAL)
+
+        path_row = wx.BoxSizer(wx.HORIZONTAL)
+        path_row.Add(wx.StaticText(self, label="Saving to: "), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        self.dest_path_label = wx.StaticText(self, label="")
+        path_row.Add(self.dest_path_label, 1,
+                     wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 4)
+        dest_sizer.Add(path_row, 0, wx.EXPAND | wx.ALL, 4)
+
+        scope_row = wx.BoxSizer(wx.HORIZONTAL)
+        scope_row.Add(wx.StaticText(self, label="Settings source: "), 0,
+                      wx.ALIGN_CENTER_VERTICAL)
+        self.dest_scope_label = wx.StaticText(self, label="")
+        scope_row.Add(self.dest_scope_label, 0,
+                      wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 4)
+        dest_sizer.Add(scope_row, 0, wx.EXPAND | wx.ALL, 4)
+
+        main_sizer.Add(dest_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+        self._refresh_destination()
+
         # Bottom row: ⚙ Settings on the left, OK/Cancel on the right.
         button_row = wx.BoxSizer(wx.HORIZONTAL)
         settings_btn = wx.Button(self, label="⚙ Settings…")
@@ -774,6 +799,27 @@ class LCSCManagerSearchDialog(wx.Dialog):
         # paths and the footprint converter's 3D URI reflect the new config.
         self.config.load_project_overrides(self.project_path)
         self.library_manager = LibraryManager(self.project_path)
+        self._refresh_destination()
+
+    def _refresh_destination(self):
+        """Update the 'Import destination' panel labels."""
+        lib_root = self.config.get_library_path(self.project_path)
+        self.dest_path_label.SetLabel(str(lib_root))
+
+        summary = self.config.get_active_scope_summary()
+        scope_text, scope_color = {
+            "project": ("This project only (.lcsc_manager.json)",
+                        wx.Colour(0, 110, 0)),
+            "mixed":   ("Project override + Global/Default for the rest",
+                        wx.Colour(0, 110, 0)),
+            "global":  ("Global (~/.kicad/lcsc_manager/config.json)",
+                        wx.Colour(20, 80, 160)),
+            "default": ("Default (no customization)",
+                        wx.Colour(120, 120, 120)),
+        }[summary]
+        self.dest_scope_label.SetLabel(scope_text)
+        self.dest_scope_label.SetForegroundColour(scope_color)
+        self.Layout()
 
     def _on_import(self, event):
         """Handle import button click - runs fetch+import in background thread"""

--- a/plugins/lcsc_manager/dialog_settings.py
+++ b/plugins/lcsc_manager/dialog_settings.py
@@ -1,0 +1,315 @@
+"""
+SettingsDialog — edit LCSC Manager library paths at global or project scope.
+
+Layout (top-down):
+    [ 4 path fields, each with a value-source badge ]
+    [ Preview block: resolved paths + existence indicators ]
+    [ Scope radio: Global / This project only ]
+    [ Warning label: changes apply to future imports only ]
+    [ Save / Reset this scope / Cancel buttons ]
+
+The dialog does not mutate the config until Save is clicked. Preview is
+recomputed from the in-dialog values on every keystroke.
+"""
+from pathlib import Path
+from typing import Dict, Optional
+
+import wx
+
+from .utils.config import Config, PATH_KEYS
+
+
+FIELD_LABELS = {
+    "library_path": "Library root path:",
+    "symbol_lib_name": "Symbol file name:",
+    "footprint_lib_name": "Footprint folder:",
+    "model_3d_path": "3D model folder:",
+}
+
+
+class SettingsDialog(wx.Dialog):
+    """Modal dialog to configure LCSC library paths."""
+
+    def __init__(self, parent, config: Config, project_path: Optional[Path]):
+        super().__init__(
+            parent,
+            title="LCSC Manager — Settings",
+            size=(820, 540),
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+        )
+
+        self.config = config
+        self.project_path = project_path
+
+        # Map of key → (wx.TextCtrl, wx.StaticText badge)
+        self.field_controls: Dict[str, tuple] = {}
+        self.preview_labels: Dict[str, wx.StaticText] = {}
+        self.preview_status: Dict[str, wx.StaticText] = {}
+
+        self._build_ui()
+        # Default scope: project if a project is open, else global.
+        self._set_scope("project" if project_path else "global")
+
+    # ─── UI construction ────────────────────────────────────────────
+
+    def _build_ui(self) -> None:
+        main = wx.BoxSizer(wx.VERTICAL)
+
+        # Fields panel
+        grid = wx.FlexGridSizer(rows=len(PATH_KEYS), cols=3, hgap=8, vgap=6)
+        grid.AddGrowableCol(1, 1)
+
+        for key in PATH_KEYS:
+            label = wx.StaticText(self, label=FIELD_LABELS[key])
+            ctrl = wx.TextCtrl(self)
+            ctrl.Bind(wx.EVT_TEXT, self._on_value_change)
+            badge = wx.StaticText(self, label="[default]")
+            badge.SetForegroundColour(wx.Colour(120, 120, 120))
+
+            grid.Add(label, 0, wx.ALIGN_CENTER_VERTICAL)
+            grid.Add(ctrl, 1, wx.EXPAND)
+            grid.Add(badge, 0, wx.ALIGN_CENTER_VERTICAL)
+            self.field_controls[key] = (ctrl, badge)
+
+        main.Add(grid, 0, wx.ALL | wx.EXPAND, 12)
+
+        # Preview block
+        preview_box = wx.StaticBox(self, label="Preview")
+        pv_sizer = wx.StaticBoxSizer(preview_box, wx.VERTICAL)
+
+        # Use a 3-column FlexGrid so long paths flex on the middle column
+        # instead of getting clipped by a fixed Wrap() width.
+        pv_grid = wx.FlexGridSizer(rows=3, cols=3, hgap=8, vgap=4)
+        pv_grid.AddGrowableCol(1, 1)
+
+        for key, title in (
+            ("symbol_lib", "Symbol library:"),
+            ("footprint_lib", "Footprint library:"),
+            ("model_3d_dir", "3D models:"),
+        ):
+            title_lbl = wx.StaticText(self, label=title)
+            title_lbl.SetMinSize((130, -1))
+            path_lbl = wx.StaticText(self, label="—")
+            status_lbl = wx.StaticText(self, label="")
+            status_lbl.SetMinSize((90, -1))
+
+            pv_grid.Add(title_lbl, 0, wx.ALIGN_CENTER_VERTICAL)
+            pv_grid.Add(path_lbl, 1, wx.ALIGN_CENTER_VERTICAL | wx.EXPAND)
+            pv_grid.Add(status_lbl, 0, wx.ALIGN_CENTER_VERTICAL)
+
+            self.preview_labels[key] = path_lbl
+            self.preview_status[key] = status_lbl
+
+        pv_sizer.Add(pv_grid, 1, wx.EXPAND | wx.ALL, 4)
+
+        main.Add(pv_sizer, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 12)
+
+        # Scope radio
+        scope_box = wx.StaticBox(self, label="Scope")
+        scope_sizer = wx.StaticBoxSizer(scope_box, wx.VERTICAL)
+
+        self.radio_global = wx.RadioButton(
+            self, label="Global (all projects)", style=wx.RB_GROUP
+        )
+        self.radio_project = wx.RadioButton(
+            self, label="This project only"
+        )
+        self.radio_global.Bind(wx.EVT_RADIOBUTTON, self._on_scope_change)
+        self.radio_project.Bind(wx.EVT_RADIOBUTTON, self._on_scope_change)
+        if self.project_path is None:
+            self.radio_project.Enable(False)
+            self.radio_project.SetLabel("This project only (no project open)")
+
+        scope_sizer.Add(self.radio_global, 0, wx.ALL, 4)
+        scope_sizer.Add(self.radio_project, 0, wx.ALL, 4)
+        main.Add(scope_sizer, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 12)
+
+        # Warning
+        warn = wx.StaticText(
+            self,
+            label="⚠ Changes apply to future imports only. "
+                  "Existing libraries are not moved automatically.",
+        )
+        warn.SetForegroundColour(wx.Colour(150, 90, 0))
+        warn.Wrap(600)
+        main.Add(warn, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 12)
+
+        # Buttons
+        btn_row = wx.BoxSizer(wx.HORIZONTAL)
+        self.reset_btn = wx.Button(self, label="Reset this scope")
+        self.reset_btn.Bind(wx.EVT_BUTTON, self._on_reset)
+        btn_row.Add(self.reset_btn, 0)
+        btn_row.AddStretchSpacer()
+
+        cancel_btn = wx.Button(self, wx.ID_CANCEL, "Cancel")
+        btn_row.Add(cancel_btn, 0, wx.RIGHT, 6)
+
+        self.save_btn = wx.Button(self, wx.ID_OK, "Save")
+        self.save_btn.Bind(wx.EVT_BUTTON, self._on_save)
+        btn_row.Add(self.save_btn, 0)
+
+        main.Add(btn_row, 0, wx.ALL | wx.EXPAND, 12)
+
+        self.SetSizer(main)
+        self.Layout()
+
+    # ─── state ──────────────────────────────────────────────────────
+
+    def _current_scope(self) -> str:
+        return "project" if self.radio_project.GetValue() else "global"
+
+    def _set_scope(self, scope: str) -> None:
+        if scope == "project" and self.project_path is not None:
+            self.radio_project.SetValue(True)
+        else:
+            self.radio_global.SetValue(True)
+        self._reload_fields_from_scope()
+
+    def _reload_fields_from_scope(self) -> None:
+        """Populate text fields with the value resolved *as seen from the
+        current scope*. Global view never inherits Project values; Project
+        view inherits Global → Default."""
+        scope = self._current_scope()
+        for key in PATH_KEYS:
+            ctrl, _ = self.field_controls[key]
+            value, _src = self.config.resolve_for_scope_view(key, scope)
+            ctrl.ChangeValue(str(value) if value is not None else "")
+        self._refresh_all()
+
+    # ─── event handlers ─────────────────────────────────────────────
+
+    def _on_scope_change(self, event):
+        self._reload_fields_from_scope()
+
+    def _on_value_change(self, event):
+        self._refresh_all()
+
+    def _on_reset(self, event):
+        scope = self._current_scope()
+        msg = (
+            f"Reset {scope} settings to defaults?\n\n"
+            + ("This will delete .lcsc_manager.json from the project."
+               if scope == "project"
+               else "This will overwrite your global config with defaults.")
+        )
+        confirm = wx.MessageBox(msg, "Confirm reset",
+                                wx.YES_NO | wx.ICON_QUESTION, self)
+        if confirm != wx.YES:
+            return
+        try:
+            self.config.clear_scope(scope, self.project_path)
+        except Exception as e:
+            wx.MessageBox(f"Reset failed: {e}", "Error", wx.OK | wx.ICON_ERROR, self)
+            return
+        self._reload_fields_from_scope()
+
+    def _on_save(self, event):
+        values, errors = self._collect_values()
+        if errors:
+            wx.MessageBox(
+                "Please fix the following errors:\n\n"
+                + "\n".join(f"• {FIELD_LABELS[k]} {msg}" for k, msg in errors.items()),
+                "Invalid input",
+                wx.OK | wx.ICON_WARNING,
+                self,
+            )
+            return
+        try:
+            self.config.save_scope(self._current_scope(), values, self.project_path)
+        except Exception as e:
+            wx.MessageBox(f"Save failed: {e}", "Error", wx.OK | wx.ICON_ERROR, self)
+            return
+        self.EndModal(wx.ID_OK)
+
+    # ─── value collection / preview ────────────────────────────────
+
+    def _collect_values(self) -> tuple:
+        """Return (values_dict, errors_dict). Errors maps key→message."""
+        values: Dict[str, str] = {}
+        errors: Dict[str, str] = {}
+        for key in PATH_KEYS:
+            ctrl, _ = self.field_controls[key]
+            raw = ctrl.GetValue().strip()
+            if not raw:
+                errors[key] = "must not be empty."
+            elif raw.startswith("/") or raw.startswith("~"):
+                errors[key] = "must be a project-relative path (no leading / or ~)."
+            elif ".." in Path(raw).parts:
+                errors[key] = "must not contain '..'."
+            values[key] = raw
+        return values, errors
+
+    def _refresh_all(self) -> None:
+        values, errors = self._collect_values()
+        self._refresh_badges()
+        self._refresh_preview(values, errors)
+        self._refresh_save_button(errors)
+
+    def _refresh_badges(self) -> None:
+        """Update [scope] badge per field.
+
+        [edited]                 — user typed a value that differs from what
+                                   this scope currently stores
+        [scope]                  — value comes from this scope's own storage
+        [source → scope]         — value is inherited from a lower layer and
+                                   would be written into `scope` on Save
+        """
+        scope = self._current_scope()
+        for key in PATH_KEYS:
+            ctrl, badge = self.field_controls[key]
+            current = ctrl.GetValue().strip()
+            stored = self.config.get_scope_values(scope).get(key)
+            if stored is not None and current != str(stored):
+                badge.SetLabel("[edited]")
+                badge.SetForegroundColour(wx.Colour(150, 90, 0))
+                continue
+            _value, source = self.config.resolve_for_scope_view(key, scope)
+            if source == scope:
+                badge.SetLabel(f"[{scope}]")
+                badge.SetForegroundColour(wx.Colour(0, 110, 0))
+            else:
+                badge.SetLabel(f"[{source} → {scope}]")
+                badge.SetForegroundColour(wx.Colour(120, 120, 120))
+
+    def _refresh_preview(self, values: Dict[str, str],
+                         errors: Dict[str, str]) -> None:
+        scope = self._current_scope()
+        # Global view: paths apply to *every* project, so show the
+        #              ${KIPRJMOD} template form rather than a specific
+        #              absolute path.
+        # Project view: show the absolute path resolved against the
+        #               currently open project.
+        show_template = (scope == "global") or (self.project_path is None)
+
+        if show_template:
+            root = values.get("library_path", "")
+            sym = values.get("symbol_lib_name", "")
+            fp = values.get("footprint_lib_name", "")
+            m3 = values.get("model_3d_path", "")
+            templates = {
+                "symbol_lib": f"${{KIPRJMOD}}/{root}/symbols/{sym}",
+                "footprint_lib": f"${{KIPRJMOD}}/{root}/{fp}",
+                "model_3d_dir": f"${{KIPRJMOD}}/{root}/{m3}",
+            }
+            for k, lbl in self.preview_labels.items():
+                lbl.SetLabel(templates[k] if not errors else "—")
+                self.preview_status[k].SetLabel("")
+        else:
+            resolved = Config.resolve_paths(values, self.project_path)
+            for k, lbl in self.preview_labels.items():
+                p = resolved.get(k)
+                if errors or p is None:
+                    lbl.SetLabel("—")
+                    self.preview_status[k].SetLabel("")
+                else:
+                    lbl.SetLabel(str(p))
+                    if p.exists():
+                        self.preview_status[k].SetLabel("✓ exists")
+                        self.preview_status[k].SetForegroundColour(wx.Colour(0, 110, 0))
+                    else:
+                        self.preview_status[k].SetLabel("(will create)")
+                        self.preview_status[k].SetForegroundColour(wx.Colour(120, 120, 120))
+        self.Layout()
+
+    def _refresh_save_button(self, errors: Dict[str, str]) -> None:
+        self.save_btn.Enable(not errors)

--- a/plugins/lcsc_manager/library/library_manager.py
+++ b/plugins/lcsc_manager/library/library_manager.py
@@ -36,16 +36,23 @@ class LibraryManager:
         self.config = get_config()
         self.logger = get_logger("library_manager")
 
-        # Initialize converters
-        self.symbol_converter = SymbolConverter()
-        self.footprint_converter = FootprintConverter()
-        self.model_3d_converter = Model3DConverter()
+        # Load any project-scope config overrides before computing paths
+        self.config.load_project_overrides(project_path)
 
         # Get library paths
         self.lib_base_path = self.config.get_library_path(project_path)
         self.symbol_lib_path = self.config.get_symbol_lib_path(project_path)
         self.footprint_lib_path = self.config.get_footprint_lib_path(project_path)
         self.model_3d_path = self.config.get_3d_model_path(project_path)
+
+        # Initialize converters. FootprintConverter needs the 3D-model URI
+        # base so the generated .kicad_mod references stay in sync with
+        # whatever library path the user configured.
+        self.symbol_converter = SymbolConverter()
+        self.footprint_converter = FootprintConverter(
+            model_uri_base=self.config.get_kiprjmod_uris()["model_3d_dir"]
+        )
+        self.model_3d_converter = Model3DConverter()
 
     def import_component(
         self,
@@ -294,7 +301,7 @@ class LibraryManager:
         lib_table_path = self.project_path.parent / "sym-lib-table"
 
         lib_name = self.config.get("symbol_lib_nickname")
-        lib_path = "${KIPRJMOD}/libs/lcsc/symbols/lcsc_imported.kicad_sym"
+        lib_path = self.config.get_kiprjmod_uris()["symbol_lib"]
 
         try:
             # Check if library table exists
@@ -342,7 +349,7 @@ class LibraryManager:
             Notification message if user action is needed, None otherwise
         """
         lib_name = self.config.get("footprint_lib_nickname")
-        lib_uri = "${KIPRJMOD}/libs/lcsc/footprints.pretty"
+        lib_uri = self.config.get_kiprjmod_uris()["footprint_lib"]
 
         # Try pcbnew API first (updates in-memory, immediately available)
         if HAS_PCBNEW:

--- a/plugins/lcsc_manager/utils/config.py
+++ b/plugins/lcsc_manager/utils/config.py
@@ -193,6 +193,30 @@ class Config:
             return "global"
         return "default"
 
+    def get_active_scope_summary(self) -> str:
+        """
+        Summarise where the effective path-config comes from across all
+        PATH_KEYS. Returns one of:
+
+            "project" — every path key is overridden at project scope
+            "global"  — every path key is overridden at global scope
+                        (and none at project)
+            "default" — no overrides anywhere; pure defaults
+            "mixed"   — at least one project override AND at least one
+                        key still inherited from a lower layer (global
+                        or default)
+
+        Useful for one-line UI hints like "Saving with project settings".
+        """
+        sources = {self.get_value_source(k) for k in PATH_KEYS}
+        if sources == {"project"}:
+            return "project"
+        if "project" in sources:
+            return "mixed"
+        if "global" in sources:
+            return "global"
+        return "default"
+
     def resolve_for_scope_view(self, key: str, scope: str) -> tuple:
         """
         What to display when editing `scope`. Returns (value, source).

--- a/plugins/lcsc_manager/utils/config.py
+++ b/plugins/lcsc_manager/utils/config.py
@@ -1,16 +1,33 @@
 """
-Configuration management for LCSC Manager plugin
+Configuration management for LCSC Manager plugin.
+
+Supports layered overrides:
+    hardcoded defaults  <  global  <  project
+
+- Global config:  ~/.kicad/lcsc_manager/config.json
+- Project config: <project_dir>/.lcsc_manager.json (sibling of .kicad_pro)
+
+Each level may contain any subset of keys; missing keys fall back to the
+next level. A project override is loaded explicitly via
+load_project_overrides() once the project path is known.
 """
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 from .logger import get_logger
 
 logger = get_logger()
 
 
+PROJECT_CONFIG_FILENAME = ".lcsc_manager.json"
+
+# Keys that participate in the layered resolution. Other keys (e.g.
+# api_timeout) live only at global scope.
+PATH_KEYS = ("library_path", "symbol_lib_name", "footprint_lib_name", "model_3d_path")
+
+
 class Config:
-    """Plugin configuration manager"""
+    """Plugin configuration manager."""
 
     DEFAULT_CONFIG = {
         "library_path": "libs/lcsc",
@@ -26,127 +43,256 @@ class Config:
     }
 
     def __init__(self, config_path: Optional[Path] = None):
-        """
-        Initialize configuration
-
-        Args:
-            config_path: Path to configuration file. If None, uses default location.
-        """
         if config_path is None:
             config_dir = Path.home() / ".kicad" / "lcsc_manager"
             config_dir.mkdir(parents=True, exist_ok=True)
             config_path = config_dir / "config.json"
 
         self.config_path = config_path
-        self._config: Dict[str, Any] = {}
+        self._global: Dict[str, Any] = {}
+        self._project: Dict[str, Any] = {}
+        self._project_path: Optional[Path] = None
         self.load()
 
+    # ─── load / save ──────────────────────────────────────────────────
+
     def load(self) -> None:
-        """Load configuration from file"""
+        """Load global configuration from file.
+
+        Note: Global stores *only user overrides*. Missing keys fall back
+        to DEFAULT_CONFIG at lookup time. We deliberately do NOT seed the
+        file with defaults — that would make every key look like a user
+        override in the Settings UI.
+        """
         try:
             if self.config_path.exists():
                 with open(self.config_path, 'r') as f:
-                    self._config = json.load(f)
+                    self._global = json.load(f)
                 logger.info(f"Configuration loaded from {self.config_path}")
             else:
-                self._config = self.DEFAULT_CONFIG.copy()
+                self._global = {}
                 self.save()
-                logger.info("Created new configuration file with defaults")
+                logger.info(f"Created empty configuration file at {self.config_path}")
         except Exception as e:
             logger.error(f"Failed to load configuration: {e}")
-            self._config = self.DEFAULT_CONFIG.copy()
+            self._global = {}
 
     def save(self) -> None:
-        """Save configuration to file"""
+        """Save global configuration to file."""
         try:
             self.config_path.parent.mkdir(parents=True, exist_ok=True)
             with open(self.config_path, 'w') as f:
-                json.dump(self._config, f, indent=2)
+                json.dump(self._global, f, indent=2)
             logger.info(f"Configuration saved to {self.config_path}")
         except Exception as e:
             logger.error(f"Failed to save configuration: {e}")
 
-    def get(self, key: str, default: Any = None) -> Any:
+    def load_project_overrides(self, project_path: Optional[Path]) -> None:
         """
-        Get configuration value
+        Load project-scope overrides from <project_dir>/.lcsc_manager.json.
 
         Args:
-            key: Configuration key
-            default: Default value if key not found
-
-        Returns:
-            Configuration value
+            project_path: Path to the .kicad_pro file (or its parent).
+                          Pass None to clear any current project overrides.
         """
-        # First check user config, then DEFAULT_CONFIG, then provided default
-        if key in self._config:
-            return self._config[key]
-        elif key in self.DEFAULT_CONFIG:
-            return self.DEFAULT_CONFIG[key]
+        if project_path is None:
+            self._project = {}
+            self._project_path = None
+            return
+
+        proj_dir = project_path.parent if project_path.is_file() else project_path
+        self._project_path = proj_dir
+        override_file = proj_dir / PROJECT_CONFIG_FILENAME
+
+        if not override_file.exists():
+            self._project = {}
+            return
+
+        try:
+            with open(override_file, 'r') as f:
+                self._project = json.load(f)
+            logger.info(f"Project overrides loaded from {override_file}")
+        except Exception as e:
+            logger.error(f"Failed to load project overrides: {e}")
+            self._project = {}
+
+    def save_scope(self, scope: str, values: Dict[str, Any],
+                   project_path: Optional[Path] = None) -> None:
+        """
+        Save values to the given scope.
+
+        Args:
+            scope: "global" or "project"
+            values: dict of key→value to merge into that scope (full replace
+                    of the scope file with these values)
+            project_path: required when scope == "project"
+        """
+        if scope == "global":
+            self._global.update(values)
+            self.save()
+        elif scope == "project":
+            if project_path is None:
+                project_path = self._project_path
+            if project_path is None:
+                raise ValueError("project_path required to save project scope")
+            proj_dir = project_path.parent if project_path.is_file() else project_path
+            override_file = proj_dir / PROJECT_CONFIG_FILENAME
+            self._project = dict(values)
+            try:
+                with open(override_file, 'w') as f:
+                    json.dump(self._project, f, indent=2)
+                logger.info(f"Project overrides saved to {override_file}")
+            except Exception as e:
+                logger.error(f"Failed to save project overrides: {e}")
+                raise
         else:
-            return default
+            raise ValueError(f"Unknown scope: {scope}")
+
+    def clear_scope(self, scope: str, project_path: Optional[Path] = None) -> None:
+        """Reset a scope. Both scopes become empty so resolution falls
+        back to lower layers (Global→Default for Project, Default for
+        Global). The project file is removed; the global file is rewritten
+        as empty JSON."""
+        if scope == "global":
+            self._global = {}
+            self.save()
+        elif scope == "project":
+            if project_path is None:
+                project_path = self._project_path
+            if project_path is None:
+                raise ValueError("project_path required to clear project scope")
+            proj_dir = project_path.parent if project_path.is_file() else project_path
+            override_file = proj_dir / PROJECT_CONFIG_FILENAME
+            self._project = {}
+            if override_file.exists():
+                try:
+                    override_file.unlink()
+                    logger.info(f"Project overrides removed: {override_file}")
+                except Exception as e:
+                    logger.error(f"Failed to remove project overrides: {e}")
+        else:
+            raise ValueError(f"Unknown scope: {scope}")
+
+    # ─── value resolution ────────────────────────────────────────────
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Resolve a key through project → global → DEFAULT_CONFIG → default."""
+        if key in self._project:
+            return self._project[key]
+        if key in self._global:
+            return self._global[key]
+        if key in self.DEFAULT_CONFIG:
+            return self.DEFAULT_CONFIG[key]
+        return default
+
+    def get_value_source(self, key: str) -> str:
+        """Return 'project' | 'global' | 'default' for the given key."""
+        if key in self._project:
+            return "project"
+        if key in self._global:
+            return "global"
+        return "default"
+
+    def resolve_for_scope_view(self, key: str, scope: str) -> tuple:
+        """
+        What to display when editing `scope`. Returns (value, source).
+
+        Global view sees only Global and Default layers — never falls back
+        to Project. Project view sees the full Project → Global → Default
+        chain (i.e., the runtime-effective value).
+        """
+        if scope == "project":
+            if key in self._project:
+                return self._project[key], "project"
+            if key in self._global:
+                return self._global[key], "global"
+            return self.DEFAULT_CONFIG.get(key), "default"
+        if scope == "global":
+            if key in self._global:
+                return self._global[key], "global"
+            return self.DEFAULT_CONFIG.get(key), "default"
+        raise ValueError(f"Unknown scope: {scope}")
 
     def set(self, key: str, value: Any) -> None:
-        """
-        Set configuration value
-
-        Args:
-            key: Configuration key
-            value: Value to set
-        """
-        self._config[key] = value
+        """Legacy: set a value in global scope and persist."""
+        self._global[key] = value
         self.save()
 
+    def get_scope_values(self, scope: str) -> Dict[str, Any]:
+        """Return raw values stored in the given scope (no merging)."""
+        if scope == "global":
+            return dict(self._global)
+        if scope == "project":
+            return dict(self._project)
+        if scope == "default":
+            return dict(self.DEFAULT_CONFIG)
+        raise ValueError(f"Unknown scope: {scope}")
+
+    # ─── path helpers ────────────────────────────────────────────────
+
+    @staticmethod
+    def resolve_paths(values: Dict[str, Any],
+                      project_path: Optional[Path]) -> Dict[str, Optional[Path]]:
+        """
+        Compute resolved filesystem paths from a values dict.
+
+        Returns a dict with keys 'library_root', 'symbol_lib', 'footprint_lib',
+        'model_3d_dir'. Values are absolute Paths when project_path is given,
+        else None (caller should display the template form instead).
+        """
+        if project_path is None:
+            return {
+                "library_root": None,
+                "symbol_lib": None,
+                "footprint_lib": None,
+                "model_3d_dir": None,
+            }
+
+        proj_dir = project_path.parent if project_path.is_file() else project_path
+        library_path = values.get("library_path", "libs/lcsc")
+        symbol_name = values.get("symbol_lib_name", "lcsc_imported.kicad_sym")
+        footprint_name = values.get("footprint_lib_name", "footprints.pretty")
+        model_dir = values.get("model_3d_path", "3dmodels")
+
+        library_root = (proj_dir / library_path).resolve()
+        return {
+            "library_root": library_root,
+            "symbol_lib": library_root / "symbols" / symbol_name,
+            "footprint_lib": library_root / footprint_name,
+            "model_3d_dir": library_root / model_dir,
+        }
+
     def get_library_path(self, project_path: Path) -> Path:
-        """
-        Get library path for a project
-
-        Args:
-            project_path: Path to KiCad project
-
-        Returns:
-            Path to library directory
-        """
-        lib_path = project_path.parent / self.get("library_path", "libs/lcsc")
-        return lib_path
+        return cast(Path, self.resolve_paths(self._effective_values(), project_path)["library_root"])
 
     def get_symbol_lib_path(self, project_path: Path) -> Path:
-        """
-        Get symbol library path
-
-        Args:
-            project_path: Path to KiCad project
-
-        Returns:
-            Path to symbol library file
-        """
-        lib_path = self.get_library_path(project_path)
-        return lib_path / "symbols" / self.get("symbol_lib_name")
+        return cast(Path, self.resolve_paths(self._effective_values(), project_path)["symbol_lib"])
 
     def get_footprint_lib_path(self, project_path: Path) -> Path:
-        """
-        Get footprint library path
-
-        Args:
-            project_path: Path to KiCad project
-
-        Returns:
-            Path to footprint library directory
-        """
-        lib_path = self.get_library_path(project_path)
-        return lib_path / self.get("footprint_lib_name")
+        return cast(Path, self.resolve_paths(self._effective_values(), project_path)["footprint_lib"])
 
     def get_3d_model_path(self, project_path: Path) -> Path:
-        """
-        Get 3D model path
+        return cast(Path, self.resolve_paths(self._effective_values(), project_path)["model_3d_dir"])
 
-        Args:
-            project_path: Path to KiCad project
-
-        Returns:
-            Path to 3D models directory
+    def get_kiprjmod_uris(self) -> Dict[str, str]:
         """
-        lib_path = self.get_library_path(project_path)
-        return lib_path / self.get("model_3d_path")
+        Return ${KIPRJMOD}-prefixed URIs used inside KiCad lib tables and
+        footprint files. Independent of the project path on disk.
+        """
+        v = self._effective_values()
+        root = v["library_path"]
+        return {
+            "library_root": f"${{KIPRJMOD}}/{root}",
+            "symbol_lib": f"${{KIPRJMOD}}/{root}/symbols/{v['symbol_lib_name']}",
+            "footprint_lib": f"${{KIPRJMOD}}/{root}/{v['footprint_lib_name']}",
+            "model_3d_dir": f"${{KIPRJMOD}}/{root}/{v['model_3d_path']}",
+        }
+
+    def _effective_values(self) -> Dict[str, Any]:
+        out = {}
+        for k in PATH_KEYS:
+            out[k] = self.get(k)
+        return out
 
 
 # Global configuration instance
@@ -154,13 +300,13 @@ _config_instance: Optional[Config] = None
 
 
 def get_config() -> Config:
-    """
-    Get global configuration instance
-
-    Returns:
-        Configuration instance
-    """
     global _config_instance
     if _config_instance is None:
         _config_instance = Config()
     return _config_instance
+
+
+def reset_config_for_tests() -> None:
+    """Test-only: clear the module-level singleton."""
+    global _config_instance
+    _config_instance = None

--- a/tests/test_config_layering.py
+++ b/tests/test_config_layering.py
@@ -1,0 +1,204 @@
+"""
+Tests for layered config resolution: default < global < project.
+
+Run with: python3 tests/test_config_layering.py
+"""
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "plugins"))
+
+from lcsc_manager.utils.config import Config, PROJECT_CONFIG_FILENAME
+
+
+def _make_config(global_data, project_dir, project_data):
+    """Create a Config with custom global + project files."""
+    global_file = project_dir / "global_config.json"
+    if global_data is not None:
+        global_file.write_text(json.dumps(global_data))
+    cfg = Config(config_path=global_file)
+    if project_data is not None:
+        (project_dir / PROJECT_CONFIG_FILENAME).write_text(json.dumps(project_data))
+    cfg.load_project_overrides(project_dir)
+    return cfg
+
+
+def test_default_only():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        cfg = _make_config({}, tmp, None)
+        assert cfg.get("library_path") == "libs/lcsc"
+        assert cfg.get_value_source("library_path") == "default"
+    print("test_default_only: PASS")
+
+
+def test_global_overrides_default():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        cfg = _make_config({"library_path": "libs/from_global"}, tmp, None)
+        assert cfg.get("library_path") == "libs/from_global"
+        assert cfg.get_value_source("library_path") == "global"
+        # Other keys still default
+        assert cfg.get("symbol_lib_name") == "lcsc_imported.kicad_sym"
+        assert cfg.get_value_source("symbol_lib_name") == "default"
+    print("test_global_overrides_default: PASS")
+
+
+def test_project_overrides_global():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        cfg = _make_config(
+            {"library_path": "libs/from_global", "symbol_lib_name": "g.kicad_sym"},
+            tmp,
+            {"library_path": "libs/from_project"},
+        )
+        assert cfg.get("library_path") == "libs/from_project"
+        assert cfg.get_value_source("library_path") == "project"
+        # Project file omits symbol_lib_name → falls back to global
+        assert cfg.get("symbol_lib_name") == "g.kicad_sym"
+        assert cfg.get_value_source("symbol_lib_name") == "global"
+    print("test_project_overrides_global: PASS")
+
+
+def test_save_scope_global_creates_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        cfg = _make_config({}, tmp, None)
+        cfg.save_scope("global", {"library_path": "custom/lib"})
+        # Re-read from disk
+        data = json.loads(cfg.config_path.read_text())
+        assert data["library_path"] == "custom/lib"
+    print("test_save_scope_global_creates_file: PASS")
+
+
+def test_save_scope_project_creates_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        cfg = _make_config({}, tmp, None)
+        cfg.save_scope("project", {"library_path": "custom/lib"}, project_path=tmp)
+        proj_file = tmp / PROJECT_CONFIG_FILENAME
+        assert proj_file.exists()
+        data = json.loads(proj_file.read_text())
+        assert data["library_path"] == "custom/lib"
+        # And the config in-memory reflects it
+        assert cfg.get("library_path") == "custom/lib"
+        assert cfg.get_value_source("library_path") == "project"
+    print("test_save_scope_project_creates_file: PASS")
+
+
+def test_clear_scope_project_deletes_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        cfg = _make_config({}, tmp, {"library_path": "x"})
+        proj_file = tmp / PROJECT_CONFIG_FILENAME
+        assert proj_file.exists()
+        cfg.clear_scope("project", project_path=tmp)
+        assert not proj_file.exists()
+        # Falls back to default
+        assert cfg.get("library_path") == "libs/lcsc"
+    print("test_clear_scope_project_deletes_file: PASS")
+
+
+def test_resolve_paths_with_project():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        values = {
+            "library_path": "libs/custom",
+            "symbol_lib_name": "my.kicad_sym",
+            "footprint_lib_name": "fp.pretty",
+            "model_3d_path": "models",
+        }
+        resolved = Config.resolve_paths(values, tmp)
+        assert resolved["library_root"] == (tmp / "libs/custom").resolve()
+        assert resolved["symbol_lib"].name == "my.kicad_sym"
+        assert resolved["symbol_lib"].parent.name == "symbols"
+        assert resolved["footprint_lib"].name == "fp.pretty"
+        assert resolved["model_3d_dir"].name == "models"
+    print("test_resolve_paths_with_project: PASS")
+
+
+def test_resolve_paths_no_project_returns_none():
+    resolved = Config.resolve_paths({"library_path": "x"}, None)
+    assert resolved["library_root"] is None
+    assert resolved["symbol_lib"] is None
+    print("test_resolve_paths_no_project_returns_none: PASS")
+
+
+def test_resolve_for_scope_view_global_ignores_project():
+    """Global view must not bleed Project values into the field."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        cfg = _make_config(
+            {"library_path": "from_global"},
+            tmp,
+            {"library_path": "from_project"},
+        )
+        # Project view: project wins
+        v, src = cfg.resolve_for_scope_view("library_path", "project")
+        assert v == "from_project" and src == "project"
+        # Global view: project is invisible — global wins
+        v, src = cfg.resolve_for_scope_view("library_path", "global")
+        assert v == "from_global" and src == "global"
+    print("test_resolve_for_scope_view_global_ignores_project: PASS")
+
+
+def test_resolve_for_scope_view_falls_through_to_default():
+    """Project view falls back through Global to Default; Global view goes
+    straight to Default when not stored."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        cfg = _make_config({}, tmp, None)
+        # Neither scope stores library_path → both views see default
+        v_g, s_g = cfg.resolve_for_scope_view("library_path", "global")
+        v_p, s_p = cfg.resolve_for_scope_view("library_path", "project")
+        assert v_g == "libs/lcsc" and s_g == "default"
+        assert v_p == "libs/lcsc" and s_p == "default"
+    print("test_resolve_for_scope_view_falls_through_to_default: PASS")
+
+
+def test_resolve_for_scope_view_project_inherits_global():
+    """Project view shows the Global value when Project doesn't override."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        cfg = _make_config({"library_path": "from_global"}, tmp, None)
+        v, src = cfg.resolve_for_scope_view("library_path", "project")
+        assert v == "from_global" and src == "global"
+    print("test_resolve_for_scope_view_project_inherits_global: PASS")
+
+
+def test_kiprjmod_uris_reflect_config():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        cfg = _make_config(
+            {
+                "library_path": "assets/lcsc",
+                "symbol_lib_name": "imported.kicad_sym",
+                "footprint_lib_name": "fp.pretty",
+                "model_3d_path": "3d",
+            },
+            tmp,
+            None,
+        )
+        uris = cfg.get_kiprjmod_uris()
+        assert uris["symbol_lib"] == "${KIPRJMOD}/assets/lcsc/symbols/imported.kicad_sym"
+        assert uris["footprint_lib"] == "${KIPRJMOD}/assets/lcsc/fp.pretty"
+        assert uris["model_3d_dir"] == "${KIPRJMOD}/assets/lcsc/3d"
+    print("test_kiprjmod_uris_reflect_config: PASS")
+
+
+if __name__ == "__main__":
+    test_default_only()
+    test_global_overrides_default()
+    test_project_overrides_global()
+    test_save_scope_global_creates_file()
+    test_save_scope_project_creates_file()
+    test_clear_scope_project_deletes_file()
+    test_resolve_paths_with_project()
+    test_resolve_paths_no_project_returns_none()
+    test_resolve_for_scope_view_global_ignores_project()
+    test_resolve_for_scope_view_falls_through_to_default()
+    test_resolve_for_scope_view_project_inherits_global()
+    test_kiprjmod_uris_reflect_config()
+    print("\nAll config layering tests passed.")

--- a/tests/test_config_layering.py
+++ b/tests/test_config_layering.py
@@ -168,6 +168,41 @@ def test_resolve_for_scope_view_project_inherits_global():
     print("test_resolve_for_scope_view_project_inherits_global: PASS")
 
 
+def test_active_scope_summary():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+
+        # Nothing overridden anywhere → default
+        cfg = _make_config({}, tmp, None)
+        assert cfg.get_active_scope_summary() == "default"
+
+        # Only global override → global
+        cfg = _make_config({"library_path": "x"}, tmp, None)
+        assert cfg.get_active_scope_summary() == "global"
+
+        # All path keys overridden at project → project
+        cfg = _make_config(
+            {},
+            tmp,
+            {
+                "library_path": "p",
+                "symbol_lib_name": "s.kicad_sym",
+                "footprint_lib_name": "f.pretty",
+                "model_3d_path": "m",
+            },
+        )
+        assert cfg.get_active_scope_summary() == "project"
+
+        # Project overrides one key, others inherit → mixed
+        cfg = _make_config(
+            {"library_path": "g"},
+            tmp,
+            {"symbol_lib_name": "s.kicad_sym"},
+        )
+        assert cfg.get_active_scope_summary() == "mixed"
+    print("test_active_scope_summary: PASS")
+
+
 def test_kiprjmod_uris_reflect_config():
     with tempfile.TemporaryDirectory() as tmp:
         tmp = Path(tmp)
@@ -200,5 +235,6 @@ if __name__ == "__main__":
     test_resolve_for_scope_view_global_ignores_project()
     test_resolve_for_scope_view_falls_through_to_default()
     test_resolve_for_scope_view_project_inherits_global()
+    test_active_scope_summary()
     test_kiprjmod_uris_reflect_config()
     print("\nAll config layering tests passed.")

--- a/tests/test_footprint_converter_3d_uri.py
+++ b/tests/test_footprint_converter_3d_uri.py
@@ -1,0 +1,46 @@
+"""
+Tests that FootprintConverter emits 3D model references using the
+configured model_uri_base, not a hardcoded path.
+
+Run with: python3 tests/test_footprint_converter_3d_uri.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "plugins"))
+
+from lcsc_manager.converters.footprint_converter import FootprintConverter
+
+
+def test_default_uri_matches_legacy_path():
+    fc = FootprintConverter()
+    assert fc.model_uri_base == "${KIPRJMOD}/libs/lcsc/3dmodels"
+    print("test_default_uri_matches_legacy_path: PASS")
+
+
+def test_custom_uri_is_stored_without_trailing_slash():
+    fc = FootprintConverter(model_uri_base="${KIPRJMOD}/assets/lcsc/3d/")
+    assert fc.model_uri_base == "${KIPRJMOD}/assets/lcsc/3d"
+    print("test_custom_uri_is_stored_without_trailing_slash: PASS")
+
+
+def test_placeholder_footprint_uses_configured_uri():
+    fc = FootprintConverter(model_uri_base="${KIPRJMOD}/assets/lcsc/3d")
+    out = fc._create_placeholder_footprint(
+        footprint_name="C123_SOT23",
+        description="test",
+        package="SOT23",
+        lcsc_id="C123",
+    )
+    # The legacy hardcoded path must not appear
+    assert "/libs/lcsc/3dmodels/" not in out
+    # The configured base does appear, with the lcsc_id appended
+    assert "${KIPRJMOD}/assets/lcsc/3d/C123.wrl" in out
+    print("test_placeholder_footprint_uses_configured_uri: PASS")
+
+
+if __name__ == "__main__":
+    test_default_uri_matches_legacy_path()
+    test_custom_uri_is_stored_without_trailing_slash()
+    test_placeholder_footprint_uses_configured_uri()
+    print("\nAll footprint_converter 3D URI tests passed.")

--- a/tests/test_library_manager_uris.py
+++ b/tests/test_library_manager_uris.py
@@ -1,0 +1,103 @@
+"""
+Tests that LibraryManager writes lib-table URIs derived from config,
+not from the legacy hardcoded literals.
+
+Run with: python3 tests/test_library_manager_uris.py
+"""
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "plugins"))
+
+# Force fresh Config so prior test state doesn't bleed in
+from lcsc_manager.utils import config as _cfg_mod
+from lcsc_manager.utils.config import Config, PROJECT_CONFIG_FILENAME
+
+
+def _setup_project(tmp: Path, overrides: dict) -> Path:
+    """Create a fake project dir with a .kicad_pro file and project overrides."""
+    proj_dir = tmp / "myproj"
+    proj_dir.mkdir()
+    proj_file = proj_dir / "myproj.kicad_pro"
+    proj_file.write_text("{}")  # KiCad project file (content doesn't matter here)
+    (proj_dir / PROJECT_CONFIG_FILENAME).write_text(json.dumps(overrides))
+    return proj_file
+
+
+def _make_global_config(tmp: Path) -> Config:
+    """Create a Config pointed at a tmp file so we don't touch ~/.kicad/."""
+    global_file = tmp / "global.json"
+    global_file.write_text("{}")
+    cfg = Config(config_path=global_file)
+    _cfg_mod._config_instance = cfg  # replace singleton
+    return cfg
+
+
+def test_symbol_lib_table_uses_config_uri():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        _make_global_config(tmp)
+        proj_file = _setup_project(tmp, {
+            "library_path": "assets/lcsc",
+            "symbol_lib_name": "components.kicad_sym",
+            "footprint_lib_name": "fp.pretty",
+            "model_3d_path": "3d",
+        })
+
+        # Import after singleton replacement
+        from lcsc_manager.library.library_manager import LibraryManager
+        lm = LibraryManager(proj_file)
+
+        notif = lm._update_symbol_lib_table()
+        assert notif is None
+        table = (proj_file.parent / "sym-lib-table").read_text()
+        assert "${KIPRJMOD}/assets/lcsc/symbols/components.kicad_sym" in table
+        # Legacy default must not leak in
+        assert "libs/lcsc/symbols/lcsc_imported.kicad_sym" not in table
+    print("test_symbol_lib_table_uses_config_uri: PASS")
+
+
+def test_footprint_lib_table_uses_config_uri():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        _make_global_config(tmp)
+        proj_file = _setup_project(tmp, {
+            "library_path": "assets/lcsc",
+            "footprint_lib_name": "fp.pretty",
+        })
+
+        from lcsc_manager.library.library_manager import LibraryManager
+        lm = LibraryManager(proj_file)
+
+        # Force the file-based fallback path
+        notif = lm._update_footprint_lib_table_file("lcsc_footprints",
+                                                   lm.config.get_kiprjmod_uris()["footprint_lib"])
+        assert notif is None
+        table = (proj_file.parent / "fp-lib-table").read_text()
+        assert "${KIPRJMOD}/assets/lcsc/fp.pretty" in table
+        assert "libs/lcsc/footprints.pretty" not in table
+    print("test_footprint_lib_table_uses_config_uri: PASS")
+
+
+def test_footprint_converter_3d_uri_reflects_config():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        _make_global_config(tmp)
+        proj_file = _setup_project(tmp, {
+            "library_path": "assets/lcsc",
+            "model_3d_path": "3d",
+        })
+
+        from lcsc_manager.library.library_manager import LibraryManager
+        lm = LibraryManager(proj_file)
+        assert lm.footprint_converter.model_uri_base == "${KIPRJMOD}/assets/lcsc/3d"
+    print("test_footprint_converter_3d_uri_reflects_config: PASS")
+
+
+if __name__ == "__main__":
+    test_symbol_lib_table_uses_config_uri()
+    test_footprint_lib_table_uses_config_uri()
+    test_footprint_converter_3d_uri_reflects_config()
+    print("\nAll library_manager URI tests passed.")


### PR DESCRIPTION
## Summary
- Resolves [#1](https://github.com/hulryung/kicad-lcsc-manager/issues/1): library paths can now be customized at **global** or **per-project** scope via an in-plugin Settings dialog. No more hand-editing JSON.
- Fixes three hardcoded `${KIPRJMOD}/libs/lcsc/…` literals (sym-lib-table URI, fp-lib-table URI, `.kicad_mod` 3D model reference) that were silently bypassing the existing config and making the documented config keys do nothing.
- Adds an **Import destination** panel to the main search dialog so users see where the next import will land and which scope's settings are active before clicking Import.

## How it works
Config resolves through three layers:
```
default  <  global (~/.kicad/lcsc_manager/config.json)
        <  project (<project>/.lcsc_manager.json)
```
Each layer may store any subset of keys (`library_path`, `symbol_lib_name`, `footprint_lib_name`, `model_3d_path`).

The Settings dialog edits one scope at a time:
- **Global view** — paths shown as `${KIPRJMOD}/…` template (project-agnostic).
- **Project view** — paths resolved against the open project, with `✓ exists` / `(will create)` indicators.
- Per-field source badge: `[global]`, `[project]`, `[default]`, `[edited]`, `[source → scope]`.
- Input validation (no empty / leading `/` or `~` / `..`).
- "Reset this scope" wipes the chosen scope cleanly.

## Test plan
- [x] Config layering — 13 unit tests in `tests/test_config_layering.py`
- [x] Lib-table URI generation — 3 unit tests in `tests/test_library_manager_uris.py`
- [x] Footprint converter 3D URI plumbing — 3 unit tests in `tests/test_footprint_converter_3d_uri.py`
- [x] All existing tests still pass (those that set `sys.path` correctly — pre-existing import failures in other tests are unrelated)
- [x] Manual KiCad smoke test on macOS / KiCad 10.0: Settings dialog renders, scope toggle swaps fields and preview, save creates `.lcsc_manager.json`, destination panel updates after save
- [ ] Reviewer: confirm behavior in Windows/Linux KiCad if possible

## Out of scope (deliberate)
- Auto-moving / renaming already-imported libraries when paths change
- KiCad path variables other than `${KIPRJMOD}`
- Multiple LCSC library destinations within one project
- Customizing the fixed `symbols/` intermediate subfolder

## Backward compatibility
- Existing global configs (which were previously seeded with all default keys) still work — they'll show every field as `[global]` until the user runs *Reset this scope*. New installs start with an empty global config so badges accurately reflect real overrides.
- Existing imports keep their paths; only future imports use the new config.